### PR TITLE
feat: 마스크 씌워진 영역 이미지로 저장

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
 				"@testing-library/react": "^13.3.0",
 				"@testing-library/user-event": "^13.5.0",
 				"axios": "^0.27.2",
+				"html2canvas": "^1.4.1",
 				"http-proxy-middleware": "^2.0.6",
 				"net": "^1.0.2",
 				"react": "^18.2.0",
@@ -2719,6 +2720,69 @@
 				"@jridgewell/sourcemap-codec": "^1.4.10"
 			}
 		},
+		"node_modules/@mapbox/node-pre-gyp": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.10.tgz",
+			"integrity": "sha512-4ySo4CjzStuprMwk35H5pPbkymjv1SF3jGLj6rAHp/xT/RF7TL7bd9CTm1xDY49K2qF7jmR/g7k+SkLETP6opA==",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"detect-libc": "^2.0.0",
+				"https-proxy-agent": "^5.0.0",
+				"make-dir": "^3.1.0",
+				"node-fetch": "^2.6.7",
+				"nopt": "^5.0.0",
+				"npmlog": "^5.0.1",
+				"rimraf": "^3.0.2",
+				"semver": "^7.3.5",
+				"tar": "^6.1.11"
+			},
+			"bin": {
+				"node-pre-gyp": "bin/node-pre-gyp"
+			}
+		},
+		"node_modules/@mapbox/node-pre-gyp/node_modules/make-dir": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+			"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"semver": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@mapbox/node-pre-gyp/node_modules/make-dir/node_modules/semver": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"optional": true,
+			"peer": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/@mapbox/node-pre-gyp/node_modules/semver": {
+			"version": "7.3.8",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -4207,6 +4271,13 @@
 			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
 			"integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA=="
 		},
+		"node_modules/abbrev": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+			"optional": true,
+			"peer": true
+		},
 		"node_modules/accepts": {
 			"version": "1.3.8",
 			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -4413,6 +4484,35 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
 			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+		},
+		"node_modules/are-we-there-yet": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
+			"integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"delegates": "^1.0.0",
+				"readable-stream": "^3.6.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/are-we-there-yet/node_modules/readable-stream": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+			"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
 		},
 		"node_modules/argparse": {
 			"version": "1.0.10",
@@ -5183,6 +5283,14 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/base64-arraybuffer": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+			"integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+			"engines": {
+				"node": ">= 0.6.0"
+			}
+		},
 		"node_modules/base64-js": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -5694,6 +5802,22 @@
 				}
 			]
 		},
+		"node_modules/canvas": {
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/canvas/-/canvas-2.11.0.tgz",
+			"integrity": "sha512-bdTjFexjKJEwtIo0oRx8eD4G2yWoUOXP9lj279jmQ2zMnTQhT8C3512OKz3s+ZOaQlLbE7TuVvRDYDB3Llyy5g==",
+			"hasInstallScript": true,
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@mapbox/node-pre-gyp": "^1.0.0",
+				"nan": "^2.17.0",
+				"simple-get": "^3.0.3"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/capture-exit": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
@@ -6010,6 +6134,16 @@
 				"simple-swizzle": "^0.2.2"
 			}
 		},
+		"node_modules/color-support": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+			"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+			"optional": true,
+			"peer": true,
+			"bin": {
+				"color-support": "bin.js"
+			}
+		},
 		"node_modules/combined-stream": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -6137,6 +6271,13 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
 			"integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA=="
+		},
+		"node_modules/console-control-strings": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+			"integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/constants-browserify": {
 			"version": "1.0.0",
@@ -6439,6 +6580,14 @@
 			},
 			"engines": {
 				"node": ">=4"
+			}
+		},
+		"node_modules/css-line-break": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+			"integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+			"dependencies": {
+				"utrie": "^1.0.2"
 			}
 		},
 		"node_modules/css-loader": {
@@ -6816,6 +6965,19 @@
 				"node": ">=0.10"
 			}
 		},
+		"node_modules/decompress-response": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+			"integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"mimic-response": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/dedent": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
@@ -7075,6 +7237,13 @@
 				"node": ">=0.4.0"
 			}
 		},
+		"node_modules/delegates": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+			"integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+			"optional": true,
+			"peer": true
+		},
 		"node_modules/depd": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -7099,6 +7268,16 @@
 			"engines": {
 				"node": ">= 0.8",
 				"npm": "1.2.8000 || >= 1.4.16"
+			}
+		},
+		"node_modules/detect-libc": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
+			"integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/detect-newline": {
@@ -9416,6 +9595,27 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/gauge": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
+			"integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"aproba": "^1.0.3 || ^2.0.0",
+				"color-support": "^1.1.2",
+				"console-control-strings": "^1.0.0",
+				"has-unicode": "^2.0.1",
+				"object-assign": "^4.1.1",
+				"signal-exit": "^3.0.0",
+				"string-width": "^4.2.3",
+				"strip-ansi": "^6.0.1",
+				"wide-align": "^1.1.2"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/gensync": {
 			"version": "1.0.0-beta.2",
 			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -9688,6 +9888,13 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/has-unicode": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+			"integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+			"optional": true,
+			"peer": true
+		},
 		"node_modules/has-value": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
@@ -9944,6 +10151,18 @@
 			},
 			"engines": {
 				"node": ">=4.0.0"
+			}
+		},
+		"node_modules/html2canvas": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+			"integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+			"dependencies": {
+				"css-line-break": "^2.1.0",
+				"text-segmentation": "^1.0.3"
+			},
+			"engines": {
+				"node": ">=8.0.0"
 			}
 		},
 		"node_modules/htmlparser2": {
@@ -13336,6 +13555,19 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/mimic-response": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
+			"integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/min-indent": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -13672,6 +13904,52 @@
 				"tslib": "^2.0.3"
 			}
 		},
+		"node_modules/node-fetch": {
+			"version": "2.6.7",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+			"integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"whatwg-url": "^5.0.0"
+			},
+			"engines": {
+				"node": "4.x || >=6.0.0"
+			},
+			"peerDependencies": {
+				"encoding": "^0.1.0"
+			},
+			"peerDependenciesMeta": {
+				"encoding": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/node-fetch/node_modules/tr46": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/node-fetch/node_modules/webidl-conversions": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/node-fetch/node_modules/whatwg-url": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"tr46": "~0.0.3",
+				"webidl-conversions": "^3.0.0"
+			}
+		},
 		"node_modules/node-forge": {
 			"version": "0.10.0",
 			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
@@ -13739,6 +14017,22 @@
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
 			"integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg=="
 		},
+		"node_modules/nopt": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+			"integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"abbrev": "1"
+			},
+			"bin": {
+				"nopt": "bin/nopt.js"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/normalize-package-data": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -13797,6 +14091,19 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/npmlog": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
+			"integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"are-we-there-yet": "^2.0.0",
+				"console-control-strings": "^1.1.0",
+				"gauge": "^3.0.0",
+				"set-blocking": "^2.0.0"
 			}
 		},
 		"node_modules/nth-check": {
@@ -18047,6 +18354,39 @@
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
 		},
+		"node_modules/simple-concat": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+			"integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/simple-get": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
+			"integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"decompress-response": "^4.2.0",
+				"once": "^1.3.1",
+				"simple-concat": "^1.0.0"
+			}
+		},
 		"node_modules/simple-swizzle": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
@@ -19404,6 +19744,14 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/text-segmentation": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+			"integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+			"dependencies": {
+				"utrie": "^1.0.2"
+			}
+		},
 		"node_modules/text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -20076,6 +20424,14 @@
 			"integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
 			"engines": {
 				"node": ">= 0.4.0"
+			}
+		},
+		"node_modules/utrie": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+			"integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+			"dependencies": {
+				"base64-arraybuffer": "^1.0.2"
 			}
 		},
 		"node_modules/uuid": {
@@ -21579,6 +21935,16 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
 			"integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q=="
+		},
+		"node_modules/wide-align": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+			"integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"string-width": "^1.0.2 || 2 || 3 || 4"
+			}
 		},
 		"node_modules/word-wrap": {
 			"version": "1.2.3",
@@ -23880,6 +24246,55 @@
 				"@jridgewell/sourcemap-codec": "^1.4.10"
 			}
 		},
+		"@mapbox/node-pre-gyp": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.10.tgz",
+			"integrity": "sha512-4ySo4CjzStuprMwk35H5pPbkymjv1SF3jGLj6rAHp/xT/RF7TL7bd9CTm1xDY49K2qF7jmR/g7k+SkLETP6opA==",
+			"optional": true,
+			"peer": true,
+			"requires": {
+				"detect-libc": "^2.0.0",
+				"https-proxy-agent": "^5.0.0",
+				"make-dir": "^3.1.0",
+				"node-fetch": "^2.6.7",
+				"nopt": "^5.0.0",
+				"npmlog": "^5.0.1",
+				"rimraf": "^3.0.2",
+				"semver": "^7.3.5",
+				"tar": "^6.1.11"
+			},
+			"dependencies": {
+				"make-dir": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+					"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+					"optional": true,
+					"peer": true,
+					"requires": {
+						"semver": "^6.0.0"
+					},
+					"dependencies": {
+						"semver": {
+							"version": "6.3.0",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+							"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+							"optional": true,
+							"peer": true
+						}
+					}
+				},
+				"semver": {
+					"version": "7.3.8",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+					"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+					"optional": true,
+					"peer": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				}
+			}
+		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -25015,6 +25430,13 @@
 			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
 			"integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA=="
 		},
+		"abbrev": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+			"optional": true,
+			"peer": true
+		},
 		"accepts": {
 			"version": "1.3.8",
 			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -25159,6 +25581,31 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
 			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+		},
+		"are-we-there-yet": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
+			"integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+			"optional": true,
+			"peer": true,
+			"requires": {
+				"delegates": "^1.0.0",
+				"readable-stream": "^3.6.0"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"optional": true,
+					"peer": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
+			}
 		},
 		"argparse": {
 			"version": "1.0.10",
@@ -25767,6 +26214,11 @@
 				}
 			}
 		},
+		"base64-arraybuffer": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+			"integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ=="
+		},
 		"base64-js": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -26179,6 +26631,18 @@
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001434.tgz",
 			"integrity": "sha512-aOBHrLmTQw//WFa2rcF1If9fa3ypkC1wzqqiKHgfdrXTWcU8C4gKVZT77eQAPWN1APys3+uQ0Df07rKauXGEYA=="
 		},
+		"canvas": {
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/canvas/-/canvas-2.11.0.tgz",
+			"integrity": "sha512-bdTjFexjKJEwtIo0oRx8eD4G2yWoUOXP9lj279jmQ2zMnTQhT8C3512OKz3s+ZOaQlLbE7TuVvRDYDB3Llyy5g==",
+			"optional": true,
+			"peer": true,
+			"requires": {
+				"@mapbox/node-pre-gyp": "^1.0.0",
+				"nan": "^2.17.0",
+				"simple-get": "^3.0.3"
+			}
+		},
 		"capture-exit": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
@@ -26426,6 +26890,13 @@
 				"simple-swizzle": "^0.2.2"
 			}
 		},
+		"color-support": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+			"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+			"optional": true,
+			"peer": true
+		},
 		"combined-stream": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -26534,6 +27005,13 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
 			"integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA=="
+		},
+		"console-control-strings": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+			"integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+			"optional": true,
+			"peer": true
 		},
 		"constants-browserify": {
 			"version": "1.0.0",
@@ -26771,6 +27249,14 @@
 						"uniq": "^1.0.1"
 					}
 				}
+			}
+		},
+		"css-line-break": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+			"integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+			"requires": {
+				"utrie": "^1.0.2"
 			}
 		},
 		"css-loader": {
@@ -27064,6 +27550,16 @@
 			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
 			"integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og=="
 		},
+		"decompress-response": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+			"integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+			"optional": true,
+			"peer": true,
+			"requires": {
+				"mimic-response": "^2.0.0"
+			}
+		},
 		"dedent": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
@@ -27260,6 +27756,13 @@
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
 			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
 		},
+		"delegates": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+			"integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+			"optional": true,
+			"peer": true
+		},
 		"depd": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -27278,6 +27781,13 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
 			"integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="
+		},
+		"detect-libc": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
+			"integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
+			"optional": true,
+			"peer": true
 		},
 		"detect-newline": {
 			"version": "3.1.0",
@@ -29025,6 +29535,24 @@
 			"resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
 			"integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="
 		},
+		"gauge": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
+			"integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
+			"optional": true,
+			"peer": true,
+			"requires": {
+				"aproba": "^1.0.3 || ^2.0.0",
+				"color-support": "^1.1.2",
+				"console-control-strings": "^1.0.0",
+				"has-unicode": "^2.0.1",
+				"object-assign": "^4.1.1",
+				"signal-exit": "^3.0.0",
+				"string-width": "^4.2.3",
+				"strip-ansi": "^6.0.1",
+				"wide-align": "^1.1.2"
+			}
+		},
 		"gensync": {
 			"version": "1.0.0-beta.2",
 			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -29217,6 +29745,13 @@
 			"requires": {
 				"has-symbols": "^1.0.2"
 			}
+		},
+		"has-unicode": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+			"integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+			"optional": true,
+			"peer": true
 		},
 		"has-value": {
 			"version": "1.0.0",
@@ -29436,6 +29971,15 @@
 						"json5": "^1.0.1"
 					}
 				}
+			}
+		},
+		"html2canvas": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+			"integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+			"requires": {
+				"css-line-break": "^2.1.0",
+				"text-segmentation": "^1.0.3"
 			}
 		},
 		"htmlparser2": {
@@ -31939,6 +32483,13 @@
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
 			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
 		},
+		"mimic-response": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
+			"integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
+			"optional": true,
+			"peer": true
+		},
 		"min-indent": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -32209,6 +32760,43 @@
 				"tslib": "^2.0.3"
 			}
 		},
+		"node-fetch": {
+			"version": "2.6.7",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+			"integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+			"optional": true,
+			"peer": true,
+			"requires": {
+				"whatwg-url": "^5.0.0"
+			},
+			"dependencies": {
+				"tr46": {
+					"version": "0.0.3",
+					"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+					"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+					"optional": true,
+					"peer": true
+				},
+				"webidl-conversions": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+					"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+					"optional": true,
+					"peer": true
+				},
+				"whatwg-url": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+					"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+					"optional": true,
+					"peer": true,
+					"requires": {
+						"tr46": "~0.0.3",
+						"webidl-conversions": "^3.0.0"
+					}
+				}
+			}
+		},
 		"node-forge": {
 			"version": "0.10.0",
 			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
@@ -32275,6 +32863,16 @@
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
 			"integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg=="
 		},
+		"nopt": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+			"integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+			"optional": true,
+			"peer": true,
+			"requires": {
+				"abbrev": "1"
+			}
+		},
 		"normalize-package-data": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -32320,6 +32918,19 @@
 			"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
 			"requires": {
 				"path-key": "^3.0.0"
+			}
+		},
+		"npmlog": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
+			"integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
+			"optional": true,
+			"peer": true,
+			"requires": {
+				"are-we-there-yet": "^2.0.0",
+				"console-control-strings": "^1.1.0",
+				"gauge": "^3.0.0",
+				"set-blocking": "^2.0.0"
 			}
 		},
 		"nth-check": {
@@ -35634,6 +36245,25 @@
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
 		},
+		"simple-concat": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+			"integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+			"optional": true,
+			"peer": true
+		},
+		"simple-get": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
+			"integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
+			"optional": true,
+			"peer": true,
+			"requires": {
+				"decompress-response": "^4.2.0",
+				"once": "^1.3.1",
+				"simple-concat": "^1.0.0"
+			}
+		},
 		"simple-swizzle": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
@@ -36700,6 +37330,14 @@
 				"minimatch": "^3.0.4"
 			}
 		},
+		"text-segmentation": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+			"integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+			"requires": {
+				"utrie": "^1.0.2"
+			}
+		},
 		"text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -37226,6 +37864,14 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
 			"integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="
+		},
+		"utrie": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+			"integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+			"requires": {
+				"base64-arraybuffer": "^1.0.2"
+			}
 		},
 		"uuid": {
 			"version": "8.3.2",
@@ -38424,6 +39070,16 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
 			"integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q=="
+		},
+		"wide-align": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+			"integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+			"optional": true,
+			"peer": true,
+			"requires": {
+				"string-width": "^1.0.2 || 2 || 3 || 4"
+			}
 		},
 		"word-wrap": {
 			"version": "1.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
 				"react-hook-form": "^7.34.0",
 				"react-icons": "^4.4.0",
 				"react-query": "^3.39.2",
+				"react-rnd": "^10.3.7",
 				"react-router-dom": "^6.3.0",
 				"react-scripts": "^4.0.0",
 				"recoil": "^0.7.5",
@@ -5931,6 +5932,14 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/clsx": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+			"integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -8898,6 +8907,11 @@
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
+		},
+		"node_modules/fast-memoize": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.5.2.tgz",
+			"integrity": "sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw=="
 		},
 		"node_modules/fastq": {
 			"version": "1.13.0",
@@ -16146,6 +16160,18 @@
 				"node": ">= 0.8"
 			}
 		},
+		"node_modules/re-resizable": {
+			"version": "6.9.6",
+			"resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.9.6.tgz",
+			"integrity": "sha512-0xYKS5+Z0zk+vICQlcZW+g54CcJTTmHluA7JUUgvERDxnKAnytylcyPsA+BSFi759s5hPlHmBRegFrwXs2FuBQ==",
+			"dependencies": {
+				"fast-memoize": "^2.5.1"
+			},
+			"peerDependencies": {
+				"react": "^16.13.1 || ^17.0.0 || ^18.0.0",
+				"react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0"
+			}
+		},
 		"node_modules/react": {
 			"version": "18.2.0",
 			"resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
@@ -16340,6 +16366,19 @@
 				"react": "^18.2.0"
 			}
 		},
+		"node_modules/react-draggable": {
+			"version": "4.4.4",
+			"resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.4.4.tgz",
+			"integrity": "sha512-6e0WdcNLwpBx/YIDpoyd2Xb04PB0elrDrulKUgdrIlwuYvxh5Ok9M+F8cljm8kPXXs43PmMzek9RrB1b7mLMqA==",
+			"dependencies": {
+				"clsx": "^1.1.1",
+				"prop-types": "^15.6.0"
+			},
+			"peerDependencies": {
+				"react": ">= 16.3.0",
+				"react-dom": ">= 16.3.0"
+			}
+		},
 		"node_modules/react-error-overlay": {
 			"version": "6.0.11",
 			"resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
@@ -16405,6 +16444,25 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/react-rnd": {
+			"version": "10.3.7",
+			"resolved": "https://registry.npmjs.org/react-rnd/-/react-rnd-10.3.7.tgz",
+			"integrity": "sha512-fYifqMI6xWzzajoRbxNNH2xpKagJT5o1zAY3a4eh4gKk+Eyy/9LGoBKA3eVX0yNOeD7JB+wznps4YmnU38v6Yw==",
+			"dependencies": {
+				"re-resizable": "6.9.6",
+				"react-draggable": "4.4.4",
+				"tslib": "2.3.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.3.0",
+				"react-dom": ">=16.3.0"
+			}
+		},
+		"node_modules/react-rnd/node_modules/tslib": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 		},
 		"node_modules/react-router": {
 			"version": "6.3.0",
@@ -26303,6 +26361,11 @@
 				"shallow-clone": "^3.0.0"
 			}
 		},
+		"clsx": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+			"integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
+		},
 		"co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -28568,6 +28631,11 @@
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
+		},
+		"fast-memoize": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.5.2.tgz",
+			"integrity": "sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw=="
 		},
 		"fastq": {
 			"version": "1.13.0",
@@ -34109,6 +34177,14 @@
 				}
 			}
 		},
+		"re-resizable": {
+			"version": "6.9.6",
+			"resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.9.6.tgz",
+			"integrity": "sha512-0xYKS5+Z0zk+vICQlcZW+g54CcJTTmHluA7JUUgvERDxnKAnytylcyPsA+BSFi759s5hPlHmBRegFrwXs2FuBQ==",
+			"requires": {
+				"fast-memoize": "^2.5.1"
+			}
+		},
 		"react": {
 			"version": "18.2.0",
 			"resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
@@ -34259,6 +34335,15 @@
 				"scheduler": "^0.23.0"
 			}
 		},
+		"react-draggable": {
+			"version": "4.4.4",
+			"resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.4.4.tgz",
+			"integrity": "sha512-6e0WdcNLwpBx/YIDpoyd2Xb04PB0elrDrulKUgdrIlwuYvxh5Ok9M+F8cljm8kPXXs43PmMzek9RrB1b7mLMqA==",
+			"requires": {
+				"clsx": "^1.1.1",
+				"prop-types": "^15.6.0"
+			}
+		},
 		"react-error-overlay": {
 			"version": "6.0.11",
 			"resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
@@ -34295,6 +34380,23 @@
 			"version": "0.8.3",
 			"resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.8.3.tgz",
 			"integrity": "sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg=="
+		},
+		"react-rnd": {
+			"version": "10.3.7",
+			"resolved": "https://registry.npmjs.org/react-rnd/-/react-rnd-10.3.7.tgz",
+			"integrity": "sha512-fYifqMI6xWzzajoRbxNNH2xpKagJT5o1zAY3a4eh4gKk+Eyy/9LGoBKA3eVX0yNOeD7JB+wznps4YmnU38v6Yw==",
+			"requires": {
+				"re-resizable": "6.9.6",
+				"react-draggable": "4.4.4",
+				"tslib": "2.3.1"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+					"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+				}
+			}
 		},
 		"react-router": {
 			"version": "6.3.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 		"react-hook-form": "^7.34.0",
 		"react-icons": "^4.4.0",
 		"react-query": "^3.39.2",
+		"react-rnd": "^10.3.7",
 		"react-router-dom": "^6.3.0",
 		"react-scripts": "^4.0.0",
 		"recoil": "^0.7.5",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 		"@testing-library/react": "^13.3.0",
 		"@testing-library/user-event": "^13.5.0",
 		"axios": "^0.27.2",
+		"html2canvas": "^1.4.1",
 		"http-proxy-middleware": "^2.0.6",
 		"net": "^1.0.2",
 		"react": "^18.2.0",

--- a/src/components/Signup/PropfileMask/ProfileMask.jsx
+++ b/src/components/Signup/PropfileMask/ProfileMask.jsx
@@ -1,17 +1,13 @@
-/* eslint-disable no-nested-ternary */
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import * as S from './ProfileMask.style';
 import Wrapper from '../../Wrapper';
-import Cropper from 'react-cropper';
-import 'cropperjs/dist/cropper.css';
+import { Rnd } from 'react-rnd';
 import { NavigateButton } from '../../Button/Button';
-import { useRecoilState } from 'recoil';
 
 const ProfileMask = () => {
 	const navigate = useNavigate();
-	const [mask, setMask] = useState(false);
-	const cropperRef = useRef(null);
+	const [mask, setMask] = useState('');
 	const maskList = [
 		{ id: 1, name: 'mask1.png' },
 		{ id: 2, name: 'mask2.png' },
@@ -24,53 +20,53 @@ const ProfileMask = () => {
 	const handleNextBtn = () => {
 		navigate('/profileSetting');
 	};
-	const onCrop = () => {
-		const imageElement = cropperRef?.current;
-		const cropper = imageElement?.cropper;
-		// console.log(cropper.getCroppedCanvas().toDataURL());
-	};
+
 	return (
 		<Wrapper>
 			<S.TitleWrapper>
-				<S.Title>가면을 씌어주세요</S.Title>
+				<S.Title>가면을 씌워주세요</S.Title>
 				<S.InfoText>
-					가면은 <S.Red>자신이 원할 때에만</S.Red> 벗어 상대방에게 공개할 수 있습니다
+					가면은 <S.Red>자신이 원할 때에만</S.Red> 벗을 수 있으며, 그 전까지는
 				</S.InfoText>
+				<S.InfoText>가면을 쓴 상태로 유지됩니다.</S.InfoText>
 			</S.TitleWrapper>
 			<S.Content>
 				<S.ImageWrapper>
-					<Cropper
-						src={profilePreview}
-						style={{
-							width: '39rem',
-							height: '42.2rem',
-							position: 'absolute',
-							// backgroundImage: `url(${maskImg1})`,
-						}}
-						initialAspectRatio={16 / 9}
-						ref={cropperRef}
-						crop={onCrop}
-					/>
-					{/* {mask === 1 ? (
-						
-					) : mask === 2 ? (
-						<S.Mask visible={mask === false ? `false` : `true`} src={maskImg2} />
+					<S.Image src={profilePreview} />
+					{mask !== '' ? (
+						<Rnd
+							default={{
+								x: 75,
+								y: 75,
+								width: 250,
+								height: 70,
+							}}
+							minWidth={20}
+							minHeight={10}
+							bounds="window"
+						>
+							<S.MaskItem
+								alt="마스크 이미지"
+								src={require(`../../../assets/${mask}`).default}
+								style={{ width: '100%', height: '100%' }}
+							/>
+						</Rnd>
 					) : (
-						<S.Mask visible={mask === false ? `false` : `true`} src={maskImg3} />
-					)} */}
+						''
+					)}
 				</S.ImageWrapper>
 				<S.InfoMessage>
-					<S.Red>가면을 선택하여 사진을 눌러보세요</S.Red>
+					<S.Red>얼굴에 맞게 가면의 위치와 크기를 조절해보세요</S.Red>
 				</S.InfoMessage>
 				<S.MaskListWrapper>
 					<S.MaskList>
 						{maskList.map(Item => {
 							return (
-								<S.MaskItemWrapper>
+								<S.MaskItemWrapper key={Item.id}>
 									<S.MaskItem
 										value={Item.name}
-										key={Item.id}
 										src={require(`../../../assets/${Item.name}`).default}
+										onClick={() => setMask(Item.name)}
 									/>
 								</S.MaskItemWrapper>
 							);

--- a/src/components/Signup/PropfileMask/ProfileMask.jsx
+++ b/src/components/Signup/PropfileMask/ProfileMask.jsx
@@ -3,21 +3,34 @@ import { useNavigate } from 'react-router-dom';
 import * as S from './ProfileMask.style';
 import Wrapper from '../../Wrapper';
 import { Rnd } from 'react-rnd';
+import html2canvas from 'html2canvas';
 import { NavigateButton } from '../../Button/Button';
 
 const ProfileMask = () => {
 	const navigate = useNavigate();
 	const [mask, setMask] = useState('');
+	const [profilePreview, setProfilePreview] = useState(localStorage?.getItem('imageData'));
 	const maskList = [
 		{ id: 1, name: 'mask1.png' },
 		{ id: 2, name: 'mask2.png' },
 		{ id: 3, name: 'mask3.png' },
 	];
-	const [profilePreview, setProfilePreview] = useState(localStorage?.getItem('imageData'));
+
 	const handlePrevBtn = () => {
 		navigate('/profilePhoto');
 	};
+
+	const captureImg = async () => {
+		window.scrollTo(0, 0);
+		let url = '';
+		await html2canvas(document.getElementById('captureDiv')).then(async canvas => {
+			url = canvas.toDataURL('image/png').split(',')[1];
+			localStorage.setItem('maskImageData', url);
+		});
+	};
+
 	const handleNextBtn = () => {
+		captureImg();
 		navigate('/profileSetting');
 	};
 
@@ -32,28 +45,30 @@ const ProfileMask = () => {
 			</S.TitleWrapper>
 			<S.Content>
 				<S.ImageWrapper>
-					<S.Image src={profilePreview} />
-					{mask !== '' ? (
-						<Rnd
-							default={{
-								x: 75,
-								y: 75,
-								width: 250,
-								height: 70,
-							}}
-							minWidth={20}
-							minHeight={10}
-							bounds="window"
-						>
-							<S.MaskItem
-								alt="마스크 이미지"
-								src={require(`../../../assets/${mask}`).default}
-								style={{ width: '100%', height: '100%' }}
-							/>
-						</Rnd>
-					) : (
-						''
-					)}
+					<S.captureDiv id="captureDiv">
+						<S.Image src={profilePreview} />
+						{mask !== '' ? (
+							<Rnd
+								default={{
+									x: 75,
+									y: 75,
+									width: 250,
+									height: 70,
+								}}
+								minWidth={20}
+								minHeight={10}
+								bounds="window"
+							>
+								<S.MaskItem
+									alt="마스크 이미지"
+									src={require(`../../../assets/${mask}`).default}
+									style={{ width: '100%', height: '100%' }}
+								/>
+							</Rnd>
+						) : (
+							''
+						)}
+					</S.captureDiv>
 				</S.ImageWrapper>
 				<S.InfoMessage>
 					<S.Red>얼굴에 맞게 가면의 위치와 크기를 조절해보세요</S.Red>

--- a/src/components/Signup/PropfileMask/ProfileMask.style.js
+++ b/src/components/Signup/PropfileMask/ProfileMask.style.js
@@ -32,17 +32,17 @@ const Title = styled.h1`
 const InfoText = styled.p`
 	top: 7rem;
 	left: 2.4rem;
-	position: absolute;
+	position: relative;
 	width: 33.5rem;
 	height: 2rem;
-	font-family: 'Pretendard';
-	font-style: normal;
+	color: ${PALETTE.BLACK800};
 	font-weight: 700;
 	font-size: 0.8rem;
+	line-height: 20px;
 `;
 
 const Red = styled.span`
-	color: red;
+	color: ${PALETTE.PINK600};
 `;
 
 const Content = styled.div`
@@ -132,11 +132,6 @@ const Image = styled.img`
 	background-color: #eee;
 `;
 
-// const Cropper = styled.Cropper`
-// 	position: absolute;
-// 	${({ visible }) => (visible ? `position: absolute` : `display: none`)};
-// `;
-
 const Mask = styled.img`
 	width: 20rem;
 	${({ visible }) => (visible ? `position: absolute` : `display: none`)};
@@ -147,11 +142,9 @@ const MaskListWrapper = styled.section`
 	height: 10rem;
 	display: flex;
 	justify-content: center;
-	margin-top: 4rem;
 `;
 
 const MaskItemWrapper = styled.div`
-	border: 2px solid ${PALETTE.PINK600};
 	border-radius: 1.2rem;
 `;
 
@@ -182,7 +175,7 @@ const InfoMessage = styled.p`
 	position: absolute;
 	left: 0rem;
 	right: 0;
-	top: 46rem;
+	top: 40rem;
 	margin: auto;
 `;
 

--- a/src/components/Signup/PropfileMask/ProfileMask.style.js
+++ b/src/components/Signup/PropfileMask/ProfileMask.style.js
@@ -126,10 +126,18 @@ const ImageWrapper = styled.section`
 `;
 
 const Image = styled.img`
+	position: absolute;
 	width: 34.2rem;
 	height: 34.2rem;
 	border-radius: 5rem;
 	background-color: #eee;
+`;
+
+const captureDiv = styled.div`
+	position: absolute;
+	width: 34.2rem;
+	height: 34.2rem;
+	border-radius: 5rem;
 `;
 
 const Mask = styled.img`
@@ -191,7 +199,7 @@ export {
 	NextBtn,
 	ImageWrapper,
 	Image,
-	// Cropper,
+	captureDiv,
 	Mask,
 	MaskListWrapper,
 	MaskItemWrapper,


### PR DESCRIPTION
## 개요 
- 마스크 씌워진 사용자의 이미지 저장

## 작업사항
- html2canvas 라이브러리 사용
- 마스크 씌워진 영역을 캡쳐 영역으로 지정
- base64 로 인코딩하여 이미지 (png) 로 저장
- 로컬 스토리지에 저장