### PR TITLE
반려 페이지 구현, 마스크 씌운 사진 미리보기&저장하여 함께 전송, accesstoken재발급

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -28,12 +28,7 @@ api.interceptors.response.use(
 	async error => {
 		if (error?.response?.status === 401) {
 			try {
-				console.log(getCookie('refreshToken'));
-				// const originalRequest = error.config;
-				// const response = await axios.post('/api/auth/silent-refresh', {
-				// 	Authorization: `Bearer ${getCookie('refreshToken')}`,
-				// 	'Content-Type': 'application/json',
-				// });
+				const originalRequest = error.config;
 				const response = await axios({
 					method: 'post',
 					url: '/api/auth/silent-refresh',
@@ -42,15 +37,13 @@ api.interceptors.response.use(
 						Authorization: `Bearer ${getCookie('refreshToken')}`,
 					},
 				});
-				console.log(response);
 				if (response) {
 					localStorage.setItem('accesstoken', response.headers.accesstoken);
 					localStorage.setItem('expiresIn', response.headers.expiresIn);
-					// return api.request(originalRequest);
+					return api.request(originalRequest);
 				}
 			} catch (error) {
-				// console.log('세션이 만료되었습니다. 다시 로그인해 주시기 바랍니다.');
-				// alert('세션이 만료되었습니다. 다시 로그인해 주시기 바랍니다.');
+				alert('세션이 만료되었습니다. 다시 로그인해 주시기 바랍니다.');
 			}
 		}
 	},

--- a/src/components/Login/LoginAuth/LoginAuth.jsx
+++ b/src/components/Login/LoginAuth/LoginAuth.jsx
@@ -22,15 +22,12 @@ const LoginAuth = () => {
 			window.location.href = `http://localhost:3000/wait`;
 		} else {
 			// 가입이 필요한 경우
-			window.location.href = `http://localhost:3000/signup/basicInfo`;
+			// window.location.href = `http://localhost:3000/signup/basicInfo`;
 		}
 	} else {
 		// 모든 가입 완료한 상태 -> 피드 화면
 		window.location.href = `http://localhost:3000/home`;
 	}
-
-	console.log(`$role : {role}, sort : ${sort}`);
 };
-// http://www.maskting.site/oauth2/redirect?role=guest&sort=false&providerId=2493698225
 
 export default LoginAuth;

--- a/src/components/Login/LoginAuth/LoginAuth.jsx
+++ b/src/components/Login/LoginAuth/LoginAuth.jsx
@@ -15,14 +15,19 @@ const LoginAuth = () => {
 			email: email,
 		}),
 	);
-
+	console.log(provider);
 	if (role === 'guest') {
 		if (sort === 'true') {
 			// 아직 심사 대기 상태인 경우 -> 대기 화면
 			window.location.href = `http://localhost:3000/wait`;
 		} else {
-			// 가입이 필요한 경우
-			// window.location.href = `http://localhost:3000/signup/basicInfo`;
+			if (provider) {
+				// 가입이 필요한 경우
+				window.location.href = `http://localhost:3000/signup/basicInfo`;
+			} else {
+				// 심사 거절된 경우 -> 대기 + 심사 거절 화면
+				window.location.href = `http://localhost:3000/wait/fail`;
+			}
 		}
 	} else {
 		// 모든 가입 완료한 상태 -> 피드 화면

--- a/src/components/Signup/PartnerMoreInfo/PartnerMoreInfo.jsx
+++ b/src/components/Signup/PartnerMoreInfo/PartnerMoreInfo.jsx
@@ -71,7 +71,6 @@ const PartnerMoreInfo = () => {
 		setSubmit(true);
 		localStorage.setItem('basicInfo', JSON.stringify(basicInfo));
 		navigate('/signup/profilePhoto');
-
 	};
 
 	const leftSlideChange = event => {
@@ -127,7 +126,6 @@ const PartnerMoreInfo = () => {
 				partnerBodyTypesRight: parseInt(event.target.value) + 1,
 			});
 		}
-
 	};
 
 	const radioChange = e => {

--- a/src/components/Signup/ProfilePhoto/ProfilePhoto.jsx
+++ b/src/components/Signup/ProfilePhoto/ProfilePhoto.jsx
@@ -30,7 +30,7 @@ const ProfilePhoto = () => {
 		if (!e.target.files) {
 			return;
 		}
-		setImageFile(e.target.files[0]);
+		setImageFile({ originalImage: e.target.files[0] });
 		const reader = new FileReader();
 		reader.readAsDataURL(imgRef.current.files[0]);
 		reader.onload = async () => {

--- a/src/components/Signup/ProfileSetting/ProfileSetting.jsx
+++ b/src/components/Signup/ProfileSetting/ProfileSetting.jsx
@@ -16,18 +16,21 @@ function ProfileSetting() {
 	const [imageFile] = useRecoilState(imageState);
 	const navigate = useNavigate();
 	const [basicInfo, setBasicInfo] = useState(JSON.parse(localStorage?.getItem('basicInfo')) || {});
-	const [profilePreview, setProfilePreview] = useState(localStorage?.getItem('imageData') || {});
-	const { register, handleSubmit, formState, watch, setError, clearErrors } = useForm({
+	const [profilePreview, setProfilePreview] = useState(
+		localStorage?.getItem('maskImageData') || {},
+	);
+	const [photoErrorMessage, setPhotoErrorMessage] = useState(null);
+	const [isModal, setIsModal] = useState(false);
+	const [isDuplicate, setIsDuplicate] = useState(false);
+	const { register, handleSubmit, formState, watch, setError, clearErrors, errors } = useForm({
 		defaultValues: {
 			nickname: basicInfo?.nickname,
 			introduce: basicInfo?.introduce,
 		},
 	});
-	const [photoErrorMessage, setPhotoErrorMessage] = useState(null);
-
 	// MODAL
-	const [isModal, setIsModal] = useState(false);
 	const onOpenModal = () => {
+		// 중복체크
 		setIsModal(true);
 	};
 	const onCloseModal = () => {
@@ -48,8 +51,8 @@ function ProfileSetting() {
 		);
 
 		const formData = new FormData();
-		formData.append('profiles', imageFile);
-
+		formData.append('profiles', imageFile.originalImage);
+		formData.append('profiles', imageFile.maskedImage);
 
 		for (let [key, value] of Object.entries({
 			...basicInfo,
@@ -60,33 +63,6 @@ function ProfileSetting() {
 			formData.append(key, value);
 		}
 
-		// formData.append('name', 'kakao');
-		// formData.append('email', 'aa@naver.com');
-		// formData.append('gender', 'kakao');
-		// formData.append('birth', 'kakao');
-		// formData.append('location', 'kakao');
-		// formData.append('occupation', 'kakao');
-		// formData.append('providerId', 'kakao');
-		// formData.append('provider', 'kakao');
-		// formData.append('interests', 'kakao');
-		// formData.append('duty', true);
-		// formData.append('smoking', false);
-		// formData.append('drinking', 3);
-		// formData.append('height', 2);
-		// formData.append('phone', 13234242);
-		// formData.append('bodyType', 3);
-		// formData.append('religion', 'kakao');
-		// formData.append('bio', 'kakao');
-		// formData.append('nickname', 'kakao');
-		// formData.append('partnerLocations', 'kakao');
-		// formData.append('partnerDuty', 'kakao');
-		// formData.append('partnerSmoking', 'kakao');
-		// formData.append('partnerReligions', 'kakao');
-		// formData.append('partnerDrinking', 1);
-		// formData.append('partnerMinHeight', 4);
-		// formData.append('partnerMaxHeight', 170);
-		// formData.append('partnerBodyTypes', 2);
-    
 		await axios({
 			method: 'POST',
 			url: `/api/user/signup`,
@@ -111,10 +87,10 @@ function ProfileSetting() {
 
 		if (!data) {
 			//이미 사용중이라면
-			setError('nickname', { message: '이미 사용 중인 닉네임입니다' }, { shouldFocus: true });
+			setIsDuplicate(true);
 			return;
 		} else {
-			clearErrors('nickname');
+			setIsDuplicate(false);
 		}
 		setError('nickname', { message: null });
 	};
@@ -281,8 +257,8 @@ function ProfileSetting() {
 					</S.PhotoInfoWrapper>
 					{/* 닉네임 */}
 					<S.HalfInfoWrapper>
-						{formState.errors?.nickname?.message ? (
-							<S.ErrorMessage>{formState.errors?.nickname?.message}</S.ErrorMessage>
+						{isDuplicate ? (
+							<S.ErrorMessage>중복하는 닉네임입니다.</S.ErrorMessage>
 						) : (
 							<S.Label htmlFor="NickName">닉네임</S.Label>
 						)}

--- a/src/components/Signup/PropfileMask/ProfileMask.jsx
+++ b/src/components/Signup/PropfileMask/ProfileMask.jsx
@@ -5,6 +5,8 @@ import Wrapper from '../../Wrapper';
 import { Rnd } from 'react-rnd';
 import html2canvas from 'html2canvas';
 import { NavigateButton } from '../../Button/Button';
+import { useRecoilState } from 'recoil';
+import imageState from '../../../recoil';
 
 const ProfileMask = () => {
 	const navigate = useNavigate();
@@ -20,17 +22,36 @@ const ProfileMask = () => {
 		navigate('/signup/profilePhoto');
 	};
 
+	const [imageFile, setImageFile] = useRecoilState(imageState);
+
 	const captureImg = async () => {
 		window.scrollTo(0, 0);
 		let url = '';
 		await html2canvas(document.getElementById('captureDiv')).then(async canvas => {
-			url = canvas.toDataURL('image/png').split(',')[1];
-			localStorage.setItem('maskImageData', url);
+			setImageFile({
+				...imageFile,
+				maskedImage: dataURLtoFile(canvas.toDataURL('image/png'), 'maskedImage.jpg'),
+			});
+			localStorage.setItem('maskImageData', canvas.toDataURL('image/png'));
 		});
 	};
 
-	const handleNextBtn = () => {
-		captureImg();
+	const dataURLtoFile = (dataurl, fileName) => {
+		var arr = dataurl.split(','),
+			mime = arr[0].match(/:(.*?);/)[1],
+			bstr = atob(arr[1]),
+			n = bstr.length,
+			u8arr = new Uint8Array(n);
+
+		while (n--) {
+			u8arr[n] = bstr.charCodeAt(n);
+		}
+
+		return new File([u8arr], fileName, { type: mime });
+	};
+
+	const handleNextBtn = async () => {
+		await captureImg();
 		navigate('/signup/profileSetting');
 	};
 

--- a/src/pages/WaitFail.jsx
+++ b/src/pages/WaitFail.jsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import Wrapper from '../components/Wrapper';
 import { WrapperInner } from '../components/Wrapper/Wrapper.style';
 import styled from 'styled-components';
 import { Red } from '../components/Signup/PartnerMoreInfo/PartnerMoreInfo.style';
 import { BigButton } from '../components/Button/BigButton/BigButton.style';
 import SideBar from '../components/SideBar/SideBar';
+import api from '../api/api';
 
 const Title = styled.section`
 	font-size: 2.6rem;
@@ -19,9 +20,33 @@ const Content = styled.div`
 const InfoTitle = styled.ul`
 	margin-top: 3rem;
 `;
-const Line = styled.li``;
+const List = styled.div`
+	line-height: 2rem;
+`;
+const Line1 = styled.div`
+	margin-left: 1rem;
+`;
+const Line2 = styled.div`
+	margin-left: 3rem;
+`;
 
 const WaitFail = () => {
+	const [rejectReason, setRejectReason] = useState('');
+	const getRejection = async () => {
+		try {
+			const res = await api('/api/user/rejection');
+			if (res.status === 200) {
+				if (res.data.reason) {
+					setRejectReason(res.data.reason);
+				}
+			}
+		} catch (err) {
+			console.log(err);
+		}
+	};
+	useEffect(() => {
+		getRejection();
+	}, []);
 	return (
 		<Wrapper>
 			<WrapperInner>
@@ -33,12 +58,56 @@ const WaitFail = () => {
 
 				<Content>
 					<InfoTitle>
-						<p>
-							다음과 같은 사유로 가입 승인이 반려되었어요
-							<Red>
-								<Line>선정적이거나 부적절한 내용을 포함한 한줄 자기소개</Line>
-							</Red>
-						</p>
+						{rejectReason === '부적절한 프로필' && (
+							<List>
+								<div>다음과 같은 사유로 가입 승인이 반려되었어요 </div>
+								<Line1>
+									<Red>* 기준에 적합하지 않는 프로필 사진</Red>
+								</Line1>
+								<Line2>
+									* 이렇게 등록해주세요: 얼굴이 선명하게 보이는 사진, 얼굴이 정면으로 나온 사진
+								</Line2>
+								<Line2>
+									* 이런 사진은 안돼요: 단체사진이나 친구가 같이 나온 사진, 얼굴 일부가 가려진
+									사진(선글라스 등)
+								</Line2>
+							</List>
+						)}
+						{rejectReason === '사용할 수 없는 닉네임' && (
+							<List>
+								<div>다음과 같은 사유로 가입 승인이 반려되었어요 </div>
+								<Line1>
+									<Red>* 기준에 적합하지 않는 프로필 사진</Red>
+								</Line1>
+								<Line2>
+									* 이렇게 등록해주세요: 얼굴이 선명하게 보이는 사진, 얼굴이 정면으로 나온 사진
+								</Line2>
+								<Line2>
+									* 이런 사진은 안돼요: 단체사진이나 친구가 같이 나온 사진, 얼굴 일부가 가려진
+									사진(선글라스 등)
+								</Line2>
+							</List>
+						)}
+						{rejectReason === '사용할 수 없는 닉네임' && (
+							<List>
+								<div>다음과 같은 사유로 가입 승인이 반려되었어요 </div>
+								<Line1>
+									<Red>* 사용할 수 없는 닉네임</Red>
+								</Line1>
+								<Line2>* 욕설이나 비하, 비속어 및 선정적인 표현은 안돼요</Line2>
+								<Line2>* 상대방도 기분이 좋아지는 닉네임을 작성해주세요!</Line2>
+							</List>
+						)}
+						{rejectReason === '사용할 수 없는 닉네임' && (
+							<List>
+								<div>다음과 같은 사유로 가입 승인이 반려되었어요 </div>
+								<Line1>
+									<Red>* 욕설이나 비하, 비속어를 포함한 한줄 자기소개</Red>
+								</Line1>
+								<Line2>* 욕설이나 비하, 비속어 및 선정적인 표현은 안돼요</Line2>
+								<Line2>* 상대방도 기분이 좋아지는 닉네임을 작성해주세요!</Line2>
+							</List>
+						)}
 					</InfoTitle>
 				</Content>
 				<BigButton>수정하러 가기</BigButton>

--- a/src/pages/WaitFail.jsx
+++ b/src/pages/WaitFail.jsx
@@ -88,17 +88,7 @@ const WaitFail = () => {
 								</Line2>
 							</List>
 						)}
-						{rejectReason === '사용할 수 없는 닉네임' && (
-							<List>
-								<div>다음과 같은 사유로 가입 승인이 반려되었어요 </div>
-								<Line1>
-									<Red>* 사용할 수 없는 닉네임</Red>
-								</Line1>
-								<Line2>* 욕설이나 비하, 비속어 및 선정적인 표현은 안돼요</Line2>
-								<Line2>* 상대방도 기분이 좋아지는 닉네임을 작성해주세요!</Line2>
-							</List>
-						)}
-						{rejectReason === '사용할 수 없는 닉네임' && (
+						{rejectReason === '사용할 수 없는 자기소개' && (
 							<List>
 								<div>다음과 같은 사유로 가입 승인이 반려되었어요 </div>
 								<Line1>

--- a/src/recoil/index.js
+++ b/src/recoil/index.js
@@ -8,9 +8,8 @@ const imageState = atom({
 export const imageRecoil = atom({
 	key: 'imageRecoil',
 	default: {
-		selectedImage: '',
-		feedbackImageList: [],
-		cntImage: 2,
+		originalImage: '',
+		maskedImage: '',
 	},
 });
 


### PR DESCRIPTION
## 개요

1. [마스크 씌운 것 base64로 전환하여 미리보기, 사진 파일로 저장 구현](https://github.com/MASKTING/maskting-front/commit/127cd4438c980371789494849f5d32e29dd4575a)하였고
2. [이미지 파일 2개(마스크 안씌운거, 씌운거)](https://github.com/MASKTING/maskting-front/commit/ed29b618174bec2922769dd213ccb8a55f96fb36)를 recoil에 저장하여 넘겨주고, 회원가입 API쏠 때 넘겨주도록 하였고
3. [api 수정](https://github.com/MASKTING/maskting-front/commit/68b1a9f8cc190bada49d5f2087a416d7e62cda05)accesstoken 만료 시 재요청하도록 하였고
4. 반려 시 wait/fail에서 반려사유 나오도록 하였습니다.

## 작업사항

![image](https://user-images.githubusercontent.com/62178788/211797132-093f92b0-3c41-40cf-a5ab-d5bb79fa69d6.png)